### PR TITLE
Add CI workflow, bump version to 1.0.0, README polish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system libraries for OpenCV
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0
+
+      - name: Install package
+        run: pip install -e ".[test]"
+
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # BeeProject
 
+[![Tests](https://github.com/mertova/BeeProject/actions/workflows/tests.yml/badge.svg)](https://github.com/mertova/BeeProject/actions/workflows/tests.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Paper](https://img.shields.io/badge/JCDL'24-10.1145/3677389.3702599-b31b1b.svg)](https://doi.org/10.1145/3677389.3702599)
@@ -16,6 +17,7 @@ The pipeline was developed to digitize beekeeping observation records collected 
 <p align="center">
   <img src="resources/readmeImgs/workflow.png" alt="Two-step digitization workflow" width="720">
 </p>
+
 ---
 
 ## Contents
@@ -191,8 +193,6 @@ Records are keyed by image ID, then by the `--service` used for that run:
   }
 }
 ```
-
-<!-- TODO: add annotated schema diagrams here -->
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beeproject"
-version = "0.1.0"
+version = "1.0.0"
 description = "Digitization of tabular forms from scanned images"
 requires-python = ">=3.10"
 dependencies = [

--- a/test/test_geometry/test_vertex.py
+++ b/test/test_geometry/test_vertex.py
@@ -4,7 +4,6 @@ from geometry.vertex import Vertex
 
 
 class VertexTest(unittest.TestCase):
-    # todo: 1. type check 2. more than
 
     def test_init(self):
         vertex = Vertex(1, 3)
@@ -12,23 +11,32 @@ class VertexTest(unittest.TestCase):
         self.assertEqual(vertex.y, 3)
 
     def test_negative_number_init(self):
-        self.assertRaises(ValueError, Vertex, -1, 3)
+        # negative coordinates are allowed (intermediate geometry can fall outside the image)
+        vertex = Vertex(-1, 3)
+        self.assertEqual(vertex.x, -1)
+        self.assertEqual(vertex.y, 3)
 
-    def test_incorrect_type_number_init(self):
-        # todo
+    def test_coercible_input_init(self):
+        # numeric strings and floats are coerced to the nearest integer
         vertex = Vertex("1", 4.6)
-        self.assertRaises(ValueError, Vertex, "1", 4.6)
+        self.assertEqual(vertex.x, 1)
+        self.assertEqual(vertex.y, 5)
+
+    def test_non_numeric_init_raises(self):
+        self.assertRaises(ValueError, Vertex, "abc", 3)
+        self.assertRaises(ValueError, Vertex, None, 3)
 
     def test_is_more_than_1(self):
-        # todo
         v1 = Vertex(1, 3)
         v2 = Vertex(2, 3)
         self.assertTrue(v2.is_more_than(v1))
 
     def test_is_more_than_2(self):
-        v1 = Vertex(2, 4)
-        v2 = Vertex(2, 3)
+        # equal x: comparison falls through to y
+        v1 = Vertex(2, 3)
+        v2 = Vertex(2, 4)
         self.assertTrue(v2.is_more_than(v1))
+        self.assertFalse(v1.is_more_than(v2))
 
     def test_as_tuple(self):
         vertex = Vertex(2, 7)


### PR DESCRIPTION
## What

- **CI**: new GitHub Actions workflow (`.github/workflows/tests.yml`) running `pytest` on Ubuntu + Windows across Python 3.10 and 3.12, with a Tests badge added to the README. Linux jobs install `libgl1`/`libglib2.0-0` for OpenCV.
- **Version bump**: `pyproject.toml` 0.1.0 → 1.0.0, matching the existing v1.0.0 GitHub release.
- **README**: removed a leftover `TODO` comment, fixed the horizontal rule not rendering under the workflow image (missing blank line after `</p>`).
- **Test fixes**: three stale tests in `test/test_geometry/test_vertex.py` failed against the actual `Vertex` implementation and would have made CI red from day one:
  - `test_negative_number_init` expected negatives to raise; `Vertex` deliberately accepts them (intermediate geometry can fall outside the image). Now asserts they're stored.
  - `test_incorrect_type_number_init` expected coercible input (`"1"`, `4.6`) to raise; `test_input()` deliberately coerces. Split into a coercion test and a new `test_non_numeric_init_raises`.
  - `test_is_more_than_2` had an inverted expectation contradicting `is_more_than`'s docstring (equal x falls through to y).

  **No pipeline code was changed** — only the test expectations were aligned with documented behavior, so reproducibility of the paper results is unaffected.

## Verification

Full suite in a clean worktree: **65 passed, 7 skipped** (cloud-credential and private-dataset tests skip by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)